### PR TITLE
(certonly.pp) remove stale route 53 dns plugin flag

### DIFF
--- a/manifests/certonly.pp
+++ b/manifests/certonly.pp
@@ -201,7 +201,6 @@ define letsencrypt::certonly (
       $_domains = join($domains, '\' -d \'')
       $plugin_args  = [
         "--cert-name '${cert_name}' -d '${_domains}'",
-        "--dns-route53-propagation-seconds ${letsencrypt::plugin::dns_route53::propagation_seconds}",
       ]
     }
 

--- a/spec/defines/letsencrypt_certonly_spec.rb
+++ b/spec/defines/letsencrypt_certonly_spec.rb
@@ -162,7 +162,7 @@ describe 'letsencrypt::certonly' do
 
         it { is_expected.to compile.with_all_deps }
         it { is_expected.to contain_class('letsencrypt::plugin::dns_route53') }
-        it { is_expected.to contain_exec('letsencrypt certonly foo.example.com').with_command "letsencrypt --text --agree-tos --non-interactive certonly --rsa-key-size 4096 -a dns-route53 --cert-name 'foo.example.com' -d 'foo.example.com' --dns-route53-propagation-seconds 10" }
+        it { is_expected.to contain_exec('letsencrypt certonly foo.example.com').with_command "letsencrypt --text --agree-tos --non-interactive certonly --rsa-key-size 4096 -a dns-route53 --cert-name 'foo.example.com' -d 'foo.example.com'" }
       end
 
       context 'with nginx plugin' do


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
Removes Stale Route53 DNS Plugin 


#### This Pull Request (PR) fixes the following issues

The `--dns-route53-propagation-seconds` flag is no longer supported by the `certbot-dns-route53` plugin, causing certificate issuance to fail. This PR removes the flag from the `dns-route53` plugin logic and updates tests accordingly.

https://github.com/certbot/certbot/blob/16f858547fedb45c948e9f34b3215b550b42cc3d/certbot/CHANGELOG.md?plain=1#L153 


